### PR TITLE
Improve README with design decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # fern
 
 My NixOS configuration
+
+## Design decisions
+
+* **flake-parts** powers the flake.  Inputs are pinned to `nixos-unstable` and
+  `home-manager`, providing a clean way to manage modules and outputs.
+* Host definitions live under `hosts/` while reusable modules are kept in
+  `modules/`, allowing each host to mix and match only the pieces it needs.
+* A `workspace` module keeps `$HOME` tidy by overriding the XDG user
+  directories so unwanted folders are not created automatically.
+* The `audio` module enables PipeWire with EasyEffects and disables the legacy
+  PulseAudio service.
+* `graphics` configures the NVIDIA driver and sets up Hyprland via `greetd` for
+  a Wayland desktop.
+* Development tooling for Rust is provided through the `devtools` module and a
+  custom Rust overlay in `overlays/rust-toolchain.nix`.
+* Home Manager manages the `ada` user environment alongside the system
+  configuration.


### PR DESCRIPTION
## Summary
- document the design choices and layout of the NixOS config in `README.md`

## Testing
- `nix flake check` *(fails: unable to download from cache.nixos.org)*

------
https://chatgpt.com/codex/tasks/task_e_685b06a1bef48331aeb68f4001f39881