### PR TITLE
Refactor/de hardcode shared aspects

### DIFF
--- a/modules/audio.nix
+++ b/modules/audio.nix
@@ -74,7 +74,8 @@
 
       security.rtkit.enable = true;
 
-      users.users.ada.extraGroups = [ "audio" ];
+      # "audio" group membership is granted centrally in modules/users.nix,
+      # conditional on services.pipewire.enable.
 
       environment.systemPackages = with pkgs; [
         audacity

--- a/modules/cli/nh.nix
+++ b/modules/cli/nh.nix
@@ -1,15 +1,22 @@
 # modules/cli/nh.nix — nh: NixOS rebuild helper with smart clean
 { den, ... }:
 {
-  den.aspects.nh.nixos = {
-    programs.nh = {
-      enable = true;
-      flake = "/home/ada/src/fern";
-      clean = {
+  den.aspects.nh.nixos =
+    { lib, ... }:
+    {
+      programs.nh = {
         enable = true;
-        dates = "weekly";
-        extraArgs = "--keep 5 --keep-since 7d";
+        # mkDefault is safe here (cf. the trusted-users note in core.nix):
+        # upstream declares programs.nh.flake as `nullOr str` with an
+        # OPTION default of null and never defines it, so nothing competes
+        # at normal priority. Hosts where the checkout lives elsewhere
+        # just set programs.nh.flake plainly.
+        flake = lib.mkDefault "/home/ada/src/fern";
+        clean = {
+          enable = true;
+          dates = "weekly";
+          extraArgs = "--keep 5 --keep-since 7d";
+        };
       };
     };
-  };
 }

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -8,10 +8,6 @@
     { lib, ... }:
     {
       nixpkgs.config.allowUnfree = true;
-      nixpkgs.config.permittedInsecurePackages = [
-        "dotnet-sdk-6.0.428"
-        "dotnet-runtime-6.0.36"
-      ];
       nixpkgs.overlays = [
         inputs.rust-overlay.overlays.default
         inputs.zig-overlay.overlays.default

--- a/modules/defaults.nix
+++ b/modules/defaults.nix
@@ -2,8 +2,20 @@
 { den, ... }:
 {
   den.default = {
-    nixos.system.stateVersion = "25.11";
-    homeManager.home.stateVersion = "25.11";
+    # Fallbacks for hosts/users that haven't pinned their own. Each host
+    # must pin system.stateVersion at whatever release it was installed
+    # with (see host-*.nix); a fleet-wide value only happens to be
+    # correct while every machine was installed on the same release.
+    nixos =
+      { lib, ... }:
+      {
+        system.stateVersion = lib.mkDefault "25.11";
+      };
+    homeManager =
+      { lib, ... }:
+      {
+        home.stateVersion = lib.mkDefault "25.11";
+      };
 
     includes = [
       den._.define-user

--- a/modules/desktop/greetd.nix
+++ b/modules/desktop/greetd.nix
@@ -70,10 +70,7 @@
         quickshell
       ];
 
-      users.users.ada.extraGroups = [
-        "video"
-        "input"
-        "seat"
-      ];
+      # "video"/"input"/"seat" group membership is granted centrally in
+      # modules/users.nix, conditional on services.greetd.enable.
     };
 }

--- a/modules/devtools/csharp.nix
+++ b/modules/devtools/csharp.nix
@@ -4,6 +4,14 @@
     nixos =
       { pkgs, ... }:
       {
+        # Parts of the .NET toolchain here still pull in EOL dotnet 6;
+        # scope the insecure-package exception to hosts that actually
+        # carry this aspect instead of the whole fleet (was in core.nix).
+        nixpkgs.config.permittedInsecurePackages = [
+          "dotnet-sdk-6.0.428"
+          "dotnet-runtime-6.0.36"
+        ];
+
         environment.systemPackages = [
           (
             with pkgs.dotnetCorePackages;

--- a/modules/devtools/docker.nix
+++ b/modules/devtools/docker.nix
@@ -13,7 +13,8 @@
         };
       };
 
-      users.users.ada.extraGroups = [ "docker" ];
+      # "docker" group membership is granted centrally in modules/users.nix,
+      # conditional on virtualisation.docker.enable.
 
       environment.systemPackages = with pkgs; [
         docker-compose

--- a/modules/gaming.nix
+++ b/modules/gaming.nix
@@ -39,6 +39,7 @@
 
       hardware.steam-hardware.enable = true;
       services.joycond.enable = true;
-      users.users.ada.extraGroups = [ "gamemode" ];
+      # "gamemode" group membership is granted centrally in
+      # modules/users.nix, conditional on programs.gamemode.enable.
     };
 }

--- a/modules/git/bundle.nix
+++ b/modules/git/bundle.nix
@@ -27,13 +27,15 @@
       {
         options.programs.gitSuite = {
           enable = mkEnableOption "Complete Git suite configuration";
+          # No defaults: git identity is personal, not a module opinion.
+          # Each user layer must set these (see user-ada.nix).
           userName = mkOption {
             type = types.str;
-            default = "adanoelle";
+            description = "Git user name (required)";
           };
           userEmail = mkOption {
             type = types.str;
-            default = "adanoelleyoung@gmail.com";
+            description = "Git user email (required)";
           };
           editor = mkOption {
             type = types.str;

--- a/modules/git/core.nix
+++ b/modules/git/core.nix
@@ -24,16 +24,16 @@
           description = "Git package to use";
         };
 
+        # No defaults: git identity is personal, not a module opinion.
+        # gitSuite forwards these from its own (also required) options.
         userName = mkOption {
           type = types.str;
-          default = "adanoelle";
-          description = "Default git user name";
+          description = "Git user name (required)";
         };
 
         userEmail = mkOption {
           type = types.str;
-          default = "adanoelleyoung@gmail.com";
-          description = "Default git user email";
+          description = "Git user email (required)";
         };
 
         editor = mkOption {

--- a/modules/host-fern.nix
+++ b/modules/host-fern.nix
@@ -35,6 +35,10 @@
           inputs.niri.nixosModules.niri
         ];
 
+        # Frozen at the release fern was installed with. NEVER bump this:
+        # it gates stateful data migrations, not features.
+        system.stateVersion = "25.11";
+
         # Use nixpkgs niri (avoids niri-flake fetchGit evaluation issue with Smithay)
         programs.niri.package = pkgs.niri;
 

--- a/modules/host-moss.nix
+++ b/modules/host-moss.nix
@@ -30,6 +30,10 @@
         ../hosts/moss/hardware.nix
         inputs.nixos-apple-silicon.nixosModules.apple-silicon-support
       ];
+
+      # Frozen at the release moss was installed with. NEVER bump this:
+      # it gates stateful data migrations, not features.
+      system.stateVersion = "25.11";
     };
   };
 }

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -1,26 +1,43 @@
 # modules/secrets.nix — SOPS-nix integration
 { den, inputs, ... }:
 {
-  den.aspects.secrets.nixos = {
-    imports = [ inputs.sops-nix.nixosModules.sops ];
+  den.aspects.secrets = {
+    # The user-owned secret derives its owner/path from the den topology
+    # (host.users) instead of hardcoding a username. sops-nix can only
+    # give a secret one path/owner, so this assumes a single-user host —
+    # true for every host today. A multi-user host should move user
+    # secrets to home-manager-side sops (planned follow-up PR).
+    includes = [
+      (
+        { host, ... }:
+        let
+          user = (builtins.head (builtins.attrValues host.users)).userName;
+        in
+        {
+          nixos = {
+            sops.secrets."ssh_id_ed25519" = {
+              path = "/home/${user}/.ssh/github";
+              owner = user;
+              mode = "0600";
+            };
+          };
+        }
+      )
+    ];
 
-    sops.age = {
-      generateKey = true;
-      keyFile = "/var/lib/sops-nix/key.txt";
-    };
+    nixos = {
+      imports = [ inputs.sops-nix.nixosModules.sops ];
 
-    security.sudo.extraConfig = ''
-      Defaults env_keep += "SOPS_AGE_KEY_FILE"
-    '';
-
-    sops.defaultSopsFile = ../secrets/main.yaml;
-
-    sops.secrets = {
-      "ssh_id_ed25519" = {
-        path = "/home/ada/.ssh/github";
-        owner = "ada";
-        mode = "0600";
+      sops.age = {
+        generateKey = true;
+        keyFile = "/var/lib/sops-nix/key.txt";
       };
+
+      security.sudo.extraConfig = ''
+        Defaults env_keep += "SOPS_AGE_KEY_FILE"
+      '';
+
+      sops.defaultSopsFile = ../secrets/main.yaml;
     };
   };
 }

--- a/modules/users.nix
+++ b/modules/users.nix
@@ -1,22 +1,61 @@
-# modules/users.nix — user accounts and networking
+# modules/users.nix — user accounts, group membership, and networking
+#
+# Design choice (see PR "remove single-machine assumptions"): instead of
+# each service aspect reaching into users.users.<name>.extraGroups, ALL
+# group membership is centralized here, keyed on whether the relevant
+# service is actually enabled on the host. Exactly one file answers
+# "what groups does a user get, and why".
+#
+# Usernames are not hardcoded: den resolves aspects in a host context,
+# and any function in an includes tree whose required arguments are
+# satisfied by that context gets called with it (den.lib.parametric
+# fixedTo / take.atLeast). So `{ host, ... }:` below receives the den
+# host, and host.users is the topology from modules/hosts.nix.
 { den, ... }:
 {
-  den.aspects.users.nixos =
-    { pkgs, ... }:
-    {
-      users.users.ada = {
-        isNormalUser = true;
-        extraGroups = [
-          "wheel"
-          "networkmanager"
-          "i2c"
-        ];
-        shell = pkgs.fish;
-      };
+  den.aspects.users = {
+    includes = [
+      (
+        { host, ... }:
+        {
+          nixos =
+            {
+              config,
+              lib,
+              pkgs,
+              ...
+            }:
+            {
+              users.users = lib.genAttrs (map (u: u.userName) (lib.attrValues host.users)) (_: {
+                isNormalUser = true;
+                shell = pkgs.fish;
+                extraGroups =
+                  [
+                    "wheel"
+                    "networkmanager"
+                  ]
+                  # DDC/CI brightness control; hardware.i2c is enabled by
+                  # the niri aspect (modules/desktop/niri.nix).
+                  ++ lib.optionals config.hardware.i2c.enable [ "i2c" ]
+                  ++ lib.optionals config.virtualisation.docker.enable [ "docker" ]
+                  ++ lib.optionals config.services.pipewire.enable [ "audio" ]
+                  ++ lib.optionals config.programs.gamemode.enable [ "gamemode" ]
+                  ++ lib.optionals config.services.greetd.enable [
+                    "video"
+                    "input"
+                    "seat"
+                  ];
+              });
+            };
+        }
+      )
+    ];
 
+    nixos = {
       programs.fish.enable = true;
 
       networking.networkmanager.enable = true;
       services.openssh.enable = true;
     };
+  };
 }


### PR DESCRIPTION
## Summary

Shared aspects no longer assume the fleet is one machine with one user named `ada`:

- **Group membership centralized** (`modules/users.nix`): the four `users.users.ada.extraGroups` scattered across audio/docker/gaming/greetd are gone. One file now answers "what groups does a user get, and why" — each group is conditional on the service actually being enabled (`virtualisation.docker.enable` → `docker`, `services.pipewire.enable` → `audio`, `services.greetd.enable` → `video`/`input`/`seat`, `programs.gamemode.enable` → `gamemode`, `hardware.i2c.enable` → `i2c`). Usernames are derived from the den topology (`host.users`) via a parametric include.
- **secrets.nix parameterized**: the ssh key secret derives `owner`/`path` from `host.users` instead of hardcoding `ada`. sops-nix allows one path/owner per secret, so this assumes a single-user host (true everywhere today); the sops→home-manager migration for multi-user is a follow-up PR.
- **stateVersion pinned per host**: `den.default` values demoted to `mkDefault`; fern and moss (parked) each pin `system.stateVersion = "25.11"` in their host aspect with a never-bump warning.
- **dotnet-6 insecure exception** moved from fleet-wide `core.nix` into the `csharp` aspect.
- **nh flake path** is now `mkDefault` (upstream `programs.nh.flake` has only an option default of `null`, no normal-priority definition, so `mkDefault` suffices — cf. the `trusted-users` note in core.nix).
- **git identity required**: `gitSuite`/`gitCore` `userName`/`userEmail` no longer default to personal values; `user-ada.nix` already sets them explicitly and nothing else enables the suite.

## Design choices / deviations

- **Groups: inversion (option b) chosen** over per-aspect username derivation. den's parametric resolution (`fixedTo`/`take.atLeast`) makes `({ host, ... }: ...)` inside an `includes` tree receive the host context cleanly, and centralizing means service aspects stay purely about their service. Documented in `modules/users.nix`.
- **`gamemode` group**: now conditional on `programs.gamemode.enable`, but note it was already absent on fern — `den.aspects.gaming`'s nixos side is not included by any host today (only `gaming-hm` is in the desktop bundle). No behavior change either way; worth deciding separately whether fern should carry the gaming system aspect.
- **secrets aspect is dormant** (only parked moss included it; fern uses only `secrets-guard`). Verified by temporarily including it on fern: `config.sops.secrets.ssh_id_ed25519` resolves to the same owner/path as before.
- **nh flake path still points at `/home/ada/src/fern` as the fleet default** — it's just overridable now. Deriving it from topology felt speculative.

## Open question (no change made)

`modules/workspace.nix` sets XDG dirs under `$HOME/ada/media/...` (i.e. `/home/ada/ada/media`). Investigation on fern:

- `xdg.userDirs.enable` is **false**, so the whole `userDirs.extraConfig` block is **inert** — `~/.config/user-dirs.dirs` on disk contains stock `xdg-user-dirs-update` values (`~/Downloads`, `~/Pictures`, …).
- `~/ada/media/` contains only the empty `obs/` dir that the aspect's own activation script creates; real screenshots go to `~/media/screenshots` (screenshot.nix).

So the double `ada` segment looks vestigial *and* the settings never applied. Left untouched per plan — decide whether to fix the paths + enable `userDirs`, or delete the block.

## Verification

- `just check` passes; `just fmt` produced no reformats.
- statix/deadnix vs main: **zero new findings**; two pre-existing statix W20 groups (core.nix, secrets.nix) disappeared as a side effect; deadnix identical.
- **Byte-identical no-op**: `nix build .#nixosConfigurations.fern...toplevel` at HEAD produces the *exact same store path* as `/run/current-system` (`5hjbvf3l…`). Group-order differences wash out because NixOS normalizes membership when generating users-groups.json. `just test` / `just diff-gen` will trivially confirm.