### PR TITLE
Feat/archivist home taxonomy

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,14 @@
       "Bash(wc:*)",
       "Bash(git:*)",
       "Bash(true:*)",
-      "Bash(nixpkgs-fmt:*)"
+      "Bash(nixpkgs-fmt:*)",
+      "WebSearch",
+      "Bash(grep:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(nix hash:*)",
+      "Bash(nix develop:*)",
+      "Bash(nix build:*)",
+      "Bash(systemctl status:*)"
     ]
   }
 }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
 # Architecture
 
 - [Repository Layout](architecture/repository-layout.md)
+- [Home Directory Taxonomy](architecture/home-directory-taxonomy.md)
 - [The Flake Entry Point](architecture/flake-entry-point.md)
 - [Dendritic Bootstrap](architecture/dendritic-bootstrap.md)
 - [Topology & Hosts](architecture/topology-and-hosts.md)

--- a/book/src/architecture/home-directory-taxonomy.md
+++ b/book/src/architecture/home-directory-taxonomy.md
@@ -1,0 +1,108 @@
+# Home Directory Taxonomy
+
+> One capture point (`~/inbox`), filed by kind, cold storage by year.
+> The entire tree is declared by the `workspace` aspect
+> (`modules/workspace.nix`) -- nothing about the home layout is ad hoc.
+
+This page documents the *configuration side* of the home layout: which
+module owns which path, and how the tree is materialized. The
+*day-to-day filing rules* (naming, triage, category caps) live in the
+hm-managed manual at `~/docs/FILING.md`, which is source-controlled at
+`modules/_workspace/FILING.md`.
+
+## The tree
+
+```
+~/
+├── inbox/            XDG_DOWNLOAD_DIR   sole capture point, empty by design
+├── docs/             XDG_DOCUMENTS_DIR  filed documents (≤ 7 categories)
+│   ├── career/                          seed category (job hunt)
+│   └── FILING.md                        hm-managed manual (read-only symlink)
+├── notes/                               Obsidian vaults, one subdir per vault
+├── media/
+│   ├── pictures/     XDG_PICTURES_DIR   images kept for their own sake
+│   ├── screenshots/                     tool-written captures (niri, hyprshot)
+│   ├── wallpapers/                      wallpaper images (paths load-bearing)
+│   ├── video/        XDG_VIDEOS_DIR     recordings (OBS output)
+│   └── music/        XDG_MUSIC_DIR      audio library
+├── src/                                 code, one subdir per repo
+└── archive/                             cold storage: archive/<year>/…
+```
+
+`~/Desktop`, `~/Public`, and `~/Templates` intentionally do not exist:
+their XDG entries point at `$HOME`, the spec-sanctioned idiom for
+"this directory is disabled". `xdg-user-dirs-update` will not recreate
+them because Home Manager also writes `user-dirs.conf` with
+`enabled=False`.
+
+## Lifecycle
+
+Files move through the tree in one direction:
+
+1. **Capture** -- everything arriving from outside lands in `~/inbox`
+   (it is the XDG download dir, so browsers and email clients agree).
+2. **Triage** -- the inbox trends toward empty; an aging item is an
+   unmade decision.
+3. **File** -- moved to its kind: `docs/<category>/`, `notes/<vault>/`,
+   `media/<subdir>/`, or `src/<project>/`.
+4. **Archive** -- finished material moves to `archive/<year>/…`.
+   Johnny.Decimal numbering is the designed graduation path for the
+   archive, applied at archive time only -- active directories are
+   never numbered or renumbered.
+
+## How the tree is materialized
+
+The `workspace` aspect (included by the `ada` base layer, so it applies
+on every host) does three things:
+
+| Mechanism | What it produces |
+|-----------|------------------|
+| `xdg.userDirs` (enabled) | `~/.config/user-dirs.dirs` + `user-dirs.conf`, eight `XDG_*_DIR` session variables, and `createDirectories = true` mkdir-p's the five real XDG dirs at activation |
+| `home.activation.archivistTree` | mkdir-p for the non-XDG dirs: `docs/career`, `notes`, `archive`, `media/screenshots`, `media/wallpapers` |
+| `home.file."docs/FILING.md"` | the filing manual, symlinked from the Nix store |
+
+Two implementation details worth knowing:
+
+- XDG dir values are **absolute paths** built from
+  `config.home.homeDirectory`, not literal `"$HOME/…"` strings --
+  Home Manager exports them as session variables, which do not undergo
+  shell expansion. New values take effect after re-login.
+- There are deliberately **no `.keep` files**: `~/inbox` must be able
+  to look empty, because "empty inbox" is the signal that triage is
+  done.
+
+## Load-bearing paths
+
+Several other aspects read or write specific taxonomy paths. Renaming
+a directory here means touching these modules:
+
+| Path | Module | Role |
+|------|--------|------|
+| `~/inbox` | `modules/workspace.nix` | XDG download dir (browsers, portals) |
+| `~/media/screenshots` | `modules/desktop/niri.nix` | niri `screenshot-path` (built-in `Print` action) |
+| `~/media/screenshots` | `modules/desktop/screenshot.nix` | hyprshot/satty script output (`shotsDir`) |
+| `~/media/wallpapers` | `modules/desktop/hyprland.nix` | wallpaper option defaults + rotation directory |
+| `~/media/wallpapers/shrine.png` | `modules/user-ada-desktop.nix` | the configured wallpaper (swww) |
+| `~/media/video` | `modules/workspace.nix` | XDG videos dir; OBS default output |
+| `~/src` | `modules/user-ada.nix` | git identity scope (`includeIf gitdir:~/src/`) |
+| `~/docs/FILING.md` | `modules/workspace.nix` | hm-managed manual |
+
+Wallpaper filenames are config-referenced (`shrine.png`), so renaming
+a wallpaper is a Nix change, not just a file move.
+
+## Invariants
+
+- New files land in `~/inbox` and nowhere else; if an app writes
+  elsewhere by default, that app gets configured, not tolerated.
+- `ls ~` shows only the lowercase taxonomy -- a stray file or a
+  capitalized `Downloads/` means some tool bypassed the config and
+  should be traced (see the load-bearing table above).
+- Every directory is enumerated in `FILING.md`; structural changes
+  update the manual, this page, and `modules/workspace.nix` together.
+
+## Deliberately out of scope
+
+- **Preservation** -- organization is not backup. Restic/syncthing for
+  `docs`, `notes`, and `archive` is a separate concern (and PR).
+- **Johnny.Decimal today** -- deferred until the archive has a corpus
+  worth numbering.

--- a/book/src/architecture/repository-layout.md
+++ b/book/src/architecture/repository-layout.md
@@ -31,7 +31,7 @@ fern/
 │   ├── secrets.nix        # SOPS-nix, age keys
 │   ├── secrets-guard.nix  # git-secrets, trufflehog
 │   ├── monitoring.nix     # Hardware sensors (lm_sensors)
-│   ├── workspace.nix      # XDG user directories
+│   ├── workspace.nix      # Archivist home taxonomy (XDG dirs, FILING.md)
 │   ├── dev.nix            # Dev shell (just, mdbook, nixpkgs-fmt)
 │   ├── docs.nix           # mdBook documentation build
 │   ├── cli/               # CLI tool aspects

--- a/book/src/reference/aspect-index.md
+++ b/book/src/reference/aspect-index.md
@@ -145,7 +145,7 @@ Aspects providing Home Manager user-level configuration.
 
 | Aspect | File | Description |
 |--------|------|-------------|
-| `workspace` | `modules/workspace.nix` | XDG user directories |
+| `workspace` | `modules/workspace.nix` | Archivist home taxonomy: XDG user dirs (inbox/docs/media), notes + archive tree, `~/docs/FILING.md` manual |
 
 ## Infrastructure aspects
 

--- a/modules/_workspace/FILING.md
+++ b/modules/_workspace/FILING.md
@@ -1,0 +1,96 @@
+# FILING.md — the home directory filing manual
+
+This home directory is a filing system, not a junk drawer. Every file
+has exactly one designed destination, and this document is the map.
+The tree is managed declaratively by `modules/workspace.nix` in the
+fern repo — this file is itself hm-managed and read-only; edit it in
+the repo.
+
+## The tree
+
+```
+~/
+├── inbox/            capture point — the ONLY place new files land
+├── docs/             filed documents (≤ 7 categories, see index below)
+│   ├── career/         job hunt: résumés, offers, applications
+│   └── FILING.md       this manual (hm-managed symlink)
+├── notes/            Obsidian vaults — one subdir per vault, nothing loose
+├── media/
+│   ├── pictures/       photos and images kept for their own sake
+│   ├── screenshots/    tool-written captures (niri, hyprshot, satty)
+│   ├── wallpapers/     wallpaper images — these paths are LOAD-BEARING
+│   │                   (swww/hyprland config points here by name)
+│   ├── video/          recordings (OBS default output)
+│   └── music/          audio library
+├── src/              code — one subdir per repo/project
+└── archive/          cold storage, by year: archive/2026/…
+```
+
+`~/Desktop`, `~/Public`, and `~/Templates` do not exist: they are
+disabled via the spec-sanctioned idiom of pointing their XDG entries
+at `$HOME`. If an app recreates one, that app is misconfigured — fix
+the app, don't keep the directory.
+
+## Lifecycle: capture → triage → file → archive
+
+1. **Capture.** Everything arriving from outside (browser downloads,
+   email attachments, exports) lands in `~/inbox`. Nothing else ever
+   writes anywhere else by default.
+2. **Triage.** `inbox/` is empty by design. An item aging in the inbox
+   is an unmade decision — make it: file it, or delete it.
+3. **File.** Move it to its kind: `docs/<category>/`, `notes/<vault>/`,
+   `media/<subdir>/`, or `src/<project>/`.
+4. **Archive.** When something is finished — a project shipped, a
+   document superseded, a year closed — it moves to
+   `archive/<year>/…`. Archived means "kept but no longer worked on".
+
+## docs/ — category index
+
+Hard cap: **seven categories**. If an eighth seems necessary, either
+merge two existing ones or the new thing belongs in `notes/` or
+`archive/`. Current index:
+
+| Category  | Contents                                    |
+| --------- | ------------------------------------------- |
+| `career/` | résumés, job applications, offers, reviews  |
+
+(Six slots free. Add rows here when adding directories.)
+
+**Naming rule:** `YYYY-MM-DD-kebab-description.ext`, where the date is
+the **document's** date (when it was issued/signed/received), not the
+filing date. Example: `2026-03-14-acme-offer-letter.pdf`.
+
+## notes/ — thinking, not records
+
+- Vaults only. Every child of `notes/` is an Obsidian vault; no loose
+  files at the top level.
+- The distinction: **docs are *about* something; notes are the
+  thinking itself.** A signed lease → `docs/`. Your analysis of
+  whether to sign it → `notes/<vault>/`.
+
+## archive/ — by year, Johnny.Decimal-ready
+
+- Layout today: `archive/<year>/<whatever-made-sense>/`.
+- **Graduation path:** when the corpus is large enough to warrant it,
+  Johnny.Decimal numbering (`archive/10-19 finances/11 taxes/…`) is
+  applied **at archive time only**. JD never applies to active
+  directories, and existing numbers are **never renumbered** — a JD
+  number is a permanent address, that's the whole point.
+
+## media/ — subdirectory contract
+
+- `pictures/` is the XDG pictures dir; generic images live here.
+- `screenshots/` is written by tooling (niri `Print`, hyprshot
+  scripts) with timestamped names; prune freely.
+- `wallpapers/` filenames are referenced from Nix config
+  (e.g. `shrine.png`) — renaming a wallpaper means a config change.
+- `video/` is the XDG videos dir and OBS's output target.
+- `music/` is the XDG music dir.
+
+## Invariants (the archivist's oath)
+
+- `inbox/` trends toward empty.
+- Nothing valuable lives loose in `~/` — if `ls ~` shows a file,
+  something went wrong upstream.
+- Every directory in this tree is enumerated in this manual; every
+  addition updates the manual (in the repo) in the same change.

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -78,7 +78,7 @@
           # Keep your existing path and monitor options for compatibility
           path = lib.mkOption {
             type = lib.types.str;
-            default = "${config.home.homeDirectory}/Pictures/wallpaper.png";
+            default = "${config.home.homeDirectory}/media/wallpapers/wallpaper.png";
           };
           monitor = lib.mkOption {
             type = lib.types.str;
@@ -90,8 +90,8 @@
             type = lib.types.attrsOf lib.types.str;
             default = { };
             example = {
-              "HDMI-A-1" = "/home/ada/wallpapers/shrine.png";
-              "DP-2" = "/home/ada/wallpapers/forest.jpg";
+              "HDMI-A-1" = "/home/ada/media/wallpapers/shrine.png";
+              "DP-2" = "/home/ada/media/wallpapers/forest.jpg";
             };
             description = "Per-monitor wallpaper paths (optional, uses path/monitor if empty)";
           };
@@ -100,8 +100,8 @@
             type = lib.types.attrsOf lib.types.str;
             default = { };
             example = {
-              "1" = "/home/ada/wallpapers/shrine.png";
-              "2" = "/home/ada/wallpapers/mononoke_tree.png";
+              "1" = "/home/ada/media/wallpapers/shrine.png";
+              "2" = "/home/ada/media/wallpapers/mononoke_tree.png";
             };
             description = "Per-workspace wallpaper paths (optional)";
           };
@@ -171,7 +171,7 @@
             };
             directory = lib.mkOption {
               type = lib.types.str;
-              default = "${config.home.homeDirectory}/wallpapers";
+              default = "${config.home.homeDirectory}/media/wallpapers";
             };
           };
           perWorkspace = lib.mkOption {

--- a/modules/desktop/niri.nix
+++ b/modules/desktop/niri.nix
@@ -42,6 +42,9 @@ in
       }:
       {
         programs.niri.settings = {
+          # Built-in Print action target (default would resurrect ~/Pictures/Screenshots)
+          screenshot-path = "~/media/screenshots/screenshot-%Y-%m-%d_%H-%M-%S.png";
+
           # ── Named workspaces (channels) ──────────────────────
           workspaces = {
             "1-studio" = {

--- a/modules/desktop/screenshot.nix
+++ b/modules/desktop/screenshot.nix
@@ -65,8 +65,6 @@
         hyprshot_full_file
       ];
 
-      home.file."Pictures/Screenshots/.keep".text = "";
-
       xdg.configFile."satty/config.toml".text = ''
         [general]
         save-after-copy = true

--- a/modules/user-ada-desktop.nix
+++ b/modules/user-ada-desktop.nix
@@ -11,37 +11,39 @@
       den.aspects.desktop-apps
     ];
 
-    homeManager = {
-      desktop.hyprland = {
-        enable = true;
-        bar.enable = false;
-        idle.enable = true;
-        lock.enable = true;
-
-        fern = {
-          enable = false;
-          obs.enable = false;
-          themeWatcher.enable = false;
-        };
-
-        wallpaper = {
+    homeManager =
+      { config, ... }:
+      {
+        desktop.hyprland = {
           enable = true;
-          path = "/home/ada/wallpapers/shrine.png";
+          bar.enable = false;
+          idle.enable = true;
+          lock.enable = true;
 
-          transition = {
-            type = "fade";
-            duration = 1.2;
-            fps = 60;
+          fern = {
+            enable = false;
+            obs.enable = false;
+            themeWatcher.enable = false;
+          };
+
+          wallpaper = {
+            enable = true;
+            path = "${config.home.homeDirectory}/media/wallpapers/shrine.png";
+
+            transition = {
+              type = "fade";
+              duration = 1.2;
+              fps = 60;
+            };
+          };
+
+          style = {
+            gapsIn = 6;
+            gapsOut = 12;
+            border = 2;
+            rounding = 5;
           };
         };
-
-        style = {
-          gapsIn = 6;
-          gapsOut = 12;
-          border = 2;
-          rounding = 5;
-        };
       };
-    };
   };
 }

--- a/modules/user-ada.nix
+++ b/modules/user-ada.nix
@@ -17,7 +17,7 @@
     ];
 
     homeManager =
-      { pkgs, ... }:
+      { pkgs, config, ... }:
       {
         home.packages = [ pkgs.home-manager ];
 
@@ -36,7 +36,11 @@
           personal = {
             name = "adanoelle";
             email = "adanoelleyoung@gmail.com";
-            directory = "/home/ada/personal/";
+            # No trailing slash: identities.nix appends one when building
+            # the includeIf gitdir condition. ~/src is all personal today;
+            # a future work identity adds "…/src/work" and wins as the
+            # later, more-specific includeIf.
+            directory = "${config.home.homeDirectory}/src";
             signingKey = "/home/ada/.ssh/github";
           };
         };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -1,22 +1,42 @@
-# modules/workspace.nix — XDG user directories
+# modules/workspace.nix — archivist home taxonomy (see ~/docs/FILING.md)
+#
+# One capture point (~/inbox), filed by kind (docs/notes/media/src),
+# cold storage by year (~/archive). Desktop/Public/Templates are
+# disabled per the xdg-user-dirs spec by pointing them at $HOME.
 { den, ... }:
 {
   den.aspects.workspace.homeManager =
-    { lib, ... }:
+    { config, lib, ... }:
+    let
+      home = config.home.homeDirectory;
+    in
     {
-      xdg = {
-        enable = true;
-        userDirs.createDirectories = false;
-        userDirs.extraConfig = {
-          XDG_DESKTOP_DIR = "$HOME";
-          XDG_DOWNLOAD_DIR = "$HOME/ada/media/downloads";
-          XDG_PICTURES_DIR = "$HOME/ada/media/pictures";
-          XDG_VIDEOS_DIR = "$HOME/ada/media/obs";
-        };
+      xdg.enable = true;
+      xdg.userDirs = {
+        enable = true; # was false — the old block was inert
+        createDirectories = true;
+        download = "${home}/inbox";
+        documents = "${home}/docs";
+        pictures = "${home}/media/pictures";
+        videos = "${home}/media/video";
+        music = "${home}/media/music";
+        # "disabled" idiom: a user dir equal to $HOME is off per spec
+        desktop = home;
+        publicShare = home;
+        templates = home;
       };
 
-      home.activation.createObsDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        mkdir -p "$HOME/ada/media/obs"
+      # Non-XDG taxonomy dirs — same mkdir idiom HM's createDirectories uses.
+      # (No .keep files: inbox must be able to LOOK empty.)
+      home.activation.archivistTree = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        run mkdir -p $VERBOSE_ARG \
+          "${home}/docs/career" \
+          "${home}/notes" \
+          "${home}/archive" \
+          "${home}/media/screenshots" \
+          "${home}/media/wallpapers"
       '';
+
+      home.file."docs/FILING.md".source = ./_workspace/FILING.md;
     };
 }


### PR DESCRIPTION
  Title:                                                                                                                                                                                 
  feat: archivist home taxonomy — enable XDG user dirs, redesign ~ layout
                                                                                                                                                                                         
  Body:                                                     
  ## Summary

  `modules/workspace.nix` was entirely inert: it set `xdg.userDirs.extraConfig`
  but never `xdg.userDirs.enable`, so apps have been using stock `~/Downloads`,
  `~/Pictures`, etc. all along while the config pointed at a vestigial
  `~/ada/media/*` tree. This PR replaces it with a designed filing system:

  ```
  ~/
  ├── inbox/            → XDG_DOWNLOAD_DIR   (sole capture point, empty by design)
  ├── docs/             → XDG_DOCUMENTS_DIR  (filed documents, ≤7 categories)
  │   ├── career/
  │   └── FILING.md       (hm-managed manual, source: modules/_workspace/FILING.md)
  ├── notes/              (Obsidian vaults)
  ├── media/
  │   ├── pictures/     → XDG_PICTURES_DIR
  │   ├── screenshots/    (niri Print + hyprshot output)
  │   ├── wallpapers/     (config-referenced paths)
  │   ├── video/        → XDG_VIDEOS_DIR    (OBS default)
  │   └── music/        → XDG_MUSIC_DIR
  ├── src/
  └── archive/            (by year; Johnny.Decimal graduation path at archive time)
  ```

  `XDG_DESKTOP_DIR` / `XDG_PUBLICSHARE_DIR` / `XDG_TEMPLATES_DIR` → `$HOME`
  (spec-sanctioned "disabled" idiom). Lifecycle: capture → triage → file →
  archive, documented in `~/docs/FILING.md` and in a new book page
  (Architecture → Home Directory Taxonomy).

  ## Changes

  - **workspace.nix**: enable `xdg.userDirs` (+ `createDirectories`), absolute
    paths from `config.home.homeDirectory`, activation script for non-XDG dirs
    (no `.keep` files — inbox must be able to look empty), hm-managed FILING.md
  - **niri.nix**: pin `screenshot-path` to `~/media/screenshots/…` — the default
    would resurrect `~/Pictures/Screenshots` after cleanup
  - **screenshot.nix**: drop the `Pictures/Screenshots/.keep` placeholder
  - **hyprland.nix + user-ada-desktop.nix**: wallpaper defaults/examples/path
    → `~/media/wallpapers`
  - **user-ada.nix**: git personal identity `~/personal/` → `~/src` (no trailing
    slash — identities.nix appends it). `~/personal` never existed, so
    directory-scoped identity switching never worked; a future work identity
    adds `…/src/work` and wins as the later, more-specific includeIf
  - **book**: new Home Directory Taxonomy page; updated aspect-index and
    repository-layout descriptions

  ## Expected build delta (verified, nothing else)

  `nvd diff` vs previous generation: +`hm_FILING.md`, +`hm_userdirs.dirs`,
  +`hm_userdirs.conf`, −`hm_PicturesScreenshots.keep` (+6.5KiB). Content
  changes within existing paths: `hm-session-vars.sh` gains 8 `XDG_*_DIR`
  exports, git config includeIf, niri `config.kdl` screenshot-path, swww unit
  wallpaper path, HM activation script.

  ## Verification

  - [x] `just fmt`, `nix flake check` pass; zero new statix/deadnix findings vs main
  - [x] Evals: `userDirs.download` = `/home/ada/inbox`, `userDirs.desktop` =
        `/home/ada`, git includes condition = `gitdir:/home/ada/src/`
  - [x] Switched on fern; `ls ~` shows only the lowercase tree; FILING.md symlinked
  - [x] mdBook builds with the new page
  - [ ] Post-re-login: `xdg-user-dir DOWNLOAD`, browser download → inbox,
        niri Print → `~/media/screenshots/`, swww unit after placing shrine.png
  - [ ] Repeat migration cleanup on moss when it revives

  ## Out of scope (deliberate)

  - Backup/preservation (restic/syncthing) — organization ≠ preservation
  - Johnny.Decimal numbering of `archive/` — deferred until a corpus exists