### PR TITLE
feat: multi-machine sops-nix with ssh-to-age host identities

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(nix hash:*)",
       "Bash(nix develop:*)",
       "Bash(nix build:*)",
-      "Bash(systemctl status:*)"
+      "Bash(systemctl status:*)",
+      "Bash(ls:*)"
     ]
   }
 }

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,21 @@
+# .sops.yaml — recipient registry and creation rules.
+#
+# New machine registration (BEFORE its first rebuild with secrets):
+#   ssh-keyscan -t ed25519 <host> | ssh-to-age     # or on the machine:
+#   ssh-to-age < /etc/ssh/ssh_host_ed25519_key.pub
+# then add &host_<name> below, extend the rules, and run:
+#   sops updatekeys secrets/<file>.yaml
+keys:
+  # ada's personal editing key (~/.config/sops/age/keys.txt — backed up)
+  - &admin_ada age100dcyxe580rdv2cuar3rwedjptzstutwr74psc5sxxxqr64y79xsgum4yk
+  # hosts (ssh-to-age of /etc/ssh/ssh_host_ed25519_key.pub)
+  - &host_fern age1gqxz9qd4a245e4c5ruaka9e325un0zu74rrs5mugach32f7y3fyskakr4u
+  # - &host_moss age1...   # register when moss rejoins the fleet
+
+creation_rules:
+  - path_regex: ^secrets/main\.yaml$
+    key_groups:
+      - age: [ *admin_ada, *host_fern ]
+  # Per-host files later, e.g.:
+  # - path_regex: ^secrets/moss\.yaml$
+  #   key_groups: [ { age: [ *admin_ada, *host_moss ] } ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,10 @@ explicitly by a parent module.
 3. Create `modules/host-<name>.nix`: hardware import + boot aspect +
    role (+ `provides.to-users` layers if graphical)
 4. Pin `system.stateVersion` for the new host at the current release
-5. Add the host's age key as a sops recipient before enabling `secrets`
+5. Register the host as a sops recipient BEFORE the first build with the
+   `secrets` aspect (activation fails loudly otherwise):
+   `ssh-keyscan -t ed25519 <host> | ssh-to-age`, add the `&host_<name>`
+   anchor + rule to `.sops.yaml`, then `sops updatekeys secrets/*.yaml`
 
 ## Safety Rules
 

--- a/book/src/operations/adding-a-host.md
+++ b/book/src/operations/adding-a-host.md
@@ -79,7 +79,30 @@ base, then add host-specific aspects. Fleet defaults — timezone, trusted-users
 nix-ld — come from `core` via `mkDefault`; override them in the `nixos` block
 only if this machine differs.
 
-## Step 4: Test the build
+## Step 4: Register the host as a sops recipient
+
+**Do this before the first build.** Any role that includes the `secrets`
+aspect (workstation does) needs the host registered in `.sops.yaml`, or the
+first activation will fail loudly — by design.
+
+The host's decryption identity is derived from its SSH host key, so it exists
+as soon as the machine has booted NixOS once:
+
+```bash
+ssh-keyscan -t ed25519 <host> | ssh-to-age
+```
+
+Add the resulting `age1...` recipient to `.sops.yaml` as `&host_<name>`,
+extend the `creation_rules` to include it, then re-key and commit:
+
+```bash
+sops updatekeys secrets/*.yaml
+git commit -am "chore(secrets): register <host> as sops recipient"
+```
+
+See [SOPS-nix](../security/sops-nix.md) for details and recovery procedures.
+
+## Step 5: Test the build
 
 ```bash
 # Dry build (does not require the target machine)
@@ -92,7 +115,7 @@ sudo nixos-rebuild test --flake .#newhost
 nixos-rebuild test --flake .#newhost --target-host newhost --build-host localhost
 ```
 
-## Step 5: Deploy
+## Step 6: Deploy
 
 On the target machine (or via remote deploy):
 
@@ -137,4 +160,5 @@ layers to forward via `provides.to-users` -- both current machines forward
 | `modules/host-fern.nix` | Example: role-composed workstation host |
 | `modules/host-moss.nix` | Example: explicitly-composed host |
 | `modules/defaults.nix` | Defaults applied to all hosts |
+| `.sops.yaml` | Sops recipient registry (register new hosts here) |
 | `hosts/<name>/hardware.nix` | Auto-generated hardware config |

--- a/book/src/security/sops-nix.md
+++ b/book/src/security/sops-nix.md
@@ -1,82 +1,132 @@
 # SOPS-nix
 
 > Secrets are encrypted with age in `secrets/main.yaml` and decrypted
-> automatically at system activation by sops-nix.
+> automatically at system activation by sops-nix. Each host decrypts with an
+> identity derived from its SSH host key; humans edit with a personal admin
+> key.
 
 SOPS (Secrets OPerationS) encrypts secret values inside YAML files so they can
 be committed to Git safely. sops-nix integrates this into NixOS, decrypting
 secrets during system activation and placing them at specified paths with
 correct ownership and permissions.
 
-## How it works
+## Identities
 
-1. An **age key** is generated and stored at `/var/lib/sops-nix/key.txt`
-2. Secrets are encrypted in `secrets/main.yaml` using SOPS with the age public
-   key
-3. During `nixos-rebuild switch`, sops-nix decrypts each secret and writes it to
-   its configured path
-4. The decrypted files are owned by the specified user with restricted
-   permissions
+There are two kinds of age identities, both registered in `.sops.yaml` at the
+repository root:
 
-## Configuration
+| Identity      | Private key lives at                     | Used for                    |
+| ------------- | ---------------------------------------- | --------------------------- |
+| `admin_ada`   | `~/.config/sops/age/keys.txt`            | Editing secrets (humans)    |
+| `host_<name>` | `/etc/ssh/ssh_host_ed25519_key` (via ssh-to-age) | Decryption at activation |
 
-The `secrets` aspect (`modules/secrets.nix`) imports sops-nix and configures it:
+Hosts do **not** have a separate age key file. sops-nix converts the machine's
+ed25519 SSH host key into an age identity at activation time
+(`sops.age.sshKeyPaths` in `modules/secrets.nix`). The matching public
+recipient is computed with [ssh-to-age](https://github.com/Mic92/ssh-to-age):
 
-```nix
-imports = [ inputs.sops-nix.nixosModules.sops ];
-
-sops.age = {
-  generateKey = true;
-  keyFile = "/var/lib/sops-nix/key.txt";
-};
-
-sops.defaultSopsFile = ../../secrets/main.yaml;
-
-sops.secrets = {
-  "ssh_id_ed25519" = {
-    path  = "/home/ada/.ssh/github";
-    owner = "ada";
-    mode  = "0600";
-  };
-};
+```bash
+# from anywhere on the network
+ssh-keyscan -t ed25519 <host> | ssh-to-age
+# or on the machine itself
+ssh-to-age < /etc/ssh/ssh_host_ed25519_key.pub
 ```
 
-### What this does
+This means a host's secret-decryption identity exists as soon as the machine
+has booted NixOS once — there is no key to generate, distribute, or back up
+per host. Reinstalling a machine regenerates its SSH host key, which is a
+**key rotation**: re-register the new recipient (see below).
 
-- **`generateKey = true`** -- Creates the age key if it does not exist
-- **`keyFile`** -- Location of the private age key
-- **`defaultSopsFile`** -- The encrypted YAML file containing all secrets
-- **`sops.secrets.*`** -- Individual secret definitions with target path, owner,
-  and permissions
+## The `.sops.yaml` registry
 
-The SSH private key for GitHub is decrypted to `/home/ada/.ssh/github` with mode
-`0600` (owner read/write only), owned by `ada`.
+`.sops.yaml` declares every recipient as a YAML anchor and maps secret files
+to recipients via `creation_rules`:
+
+```yaml
+keys:
+  - &admin_ada age100dcyxe...
+  - &host_fern age1gqxz9qd...
+
+creation_rules:
+  - path_regex: ^secrets/main\.yaml$
+    key_groups:
+      - age: [ *admin_ada, *host_fern ]
+```
+
+When `sops` creates or re-keys a file it consults these rules, so you never
+pass recipients on the command line. After changing the registry, re-key
+existing files:
+
+```bash
+sops updatekeys secrets/main.yaml   # or secrets/*.yaml
+```
 
 ## Editing secrets
 
-To edit the encrypted secrets file:
+Editing uses the admin key and requires no sudo and no environment variables —
+sops finds `~/.config/sops/age/keys.txt` automatically:
 
 ```bash
-# Set the age key for SOPS
-export SOPS_AGE_KEY_FILE=/var/lib/sops-nix/key.txt
-
-# Edit (decrypts in-place, re-encrypts on save)
-sops secrets/main.yaml
+sops secrets/main.yaml   # decrypts to $EDITOR, re-encrypts on save
 ```
 
-The `sudo` configuration preserves `SOPS_AGE_KEY_FILE` in the environment so you
-can edit secrets with elevated privileges.
+Never edit files under `secrets/` by any other means.
 
 ## Adding a new secret
 
-1. Add the secret value to `secrets/main.yaml` using `sops`
-2. Add a `sops.secrets.<name>` entry in `secrets.nix` with the target path
-3. Rebuild with `nixos-rebuild switch`
+1. `sops secrets/main.yaml` — add the key/value
+2. Declare it in `modules/secrets.nix` under `sops.secrets.<name>` with its
+   target path, owner, and mode
+3. `just test`, then `just switch`
+
+## Registering a new machine
+
+**This must happen before the machine's first rebuild with the `secrets`
+aspect.** A host that is not a recipient cannot decrypt anything, and
+activation fails loudly — by design, so a misregistered machine is caught at
+deploy time instead of silently running without its secrets.
+
+```bash
+ssh-keyscan -t ed25519 <host> | ssh-to-age   # get the age recipient
+# add `- &host_<name> age1...` to .sops.yaml and extend creation_rules
+sops updatekeys secrets/*.yaml
+git commit -am "chore(secrets): register <host> as sops recipient"
+```
+
+The same procedure applies after reinstalling an existing machine (its host
+key, and therefore its age identity, changes).
+
+## Recovery procedures
+
+**A word of history:** the original `secrets/main.yaml` in this repository had
+a single age recipient whose private key was lost in a reinstall. The file
+became permanently undecryptable and had to be recreated from scratch, with
+every secret inside it rotated. The rules below exist so that never happens
+again.
+
+- **Every file must have at least two recipients**: `admin_ada` plus each host
+  that consumes it. Either side can recover the other.
+- **Lost/reinstalled host**: nothing is lost. Register the host's new age
+  identity and `sops updatekeys` using the admin key.
+- **Lost admin key**: while at least one registered host survives, its host
+  identity can still decrypt. On that host:
+  `sudo ssh-to-age -private-key -i /etc/ssh/ssh_host_ed25519_key` yields an
+  age identity that can re-key the files to a fresh admin key. Then rotate:
+  generate a new admin key (`age-keygen`), replace `admin_ada` in
+  `.sops.yaml`, `sops updatekeys`.
+- **Both lost**: the encrypted files are gone for good. Recreate and rotate
+  every secret. Keep an offline backup of the admin key so it never comes to
+  this.
+- **A private key was exposed** (pasted, committed, leaked): treat it as
+  burned. Generate a replacement, update `.sops.yaml`, `sops updatekeys`, and
+  rotate any secret values the burned key could have decrypted.
 
 ## Key files
 
-| File                        | Purpose                                    |
-| --------------------------- | ------------------------------------------ |
-| `modules/secrets.nix`       | SOPS-nix configuration, secret definitions |
-| `secrets/main.yaml`         | Encrypted secrets file                     |
-| `/var/lib/sops-nix/key.txt` | Age private key (not in Git)               |
+| File                          | Purpose                                        |
+| ----------------------------- | ---------------------------------------------- |
+| `.sops.yaml`                  | Recipient registry + creation rules            |
+| `modules/secrets.nix`         | sops-nix configuration, secret definitions     |
+| `secrets/main.yaml`           | Encrypted secrets file                         |
+| `~/.config/sops/age/keys.txt` | Admin (editing) age key — **keep a backup**    |
+| `/etc/ssh/ssh_host_ed25519_key` | Host identity (age via ssh-to-age), not in Git |

--- a/modules/dev.nix
+++ b/modules/dev.nix
@@ -16,6 +16,10 @@
           flake-checker
           nix-output-monitor
           nvd
+          # secrets management (see book/src/security/sops-nix.md)
+          sops
+          ssh-to-age
+          age
         ];
       };
     };

--- a/modules/roles/server.nix
+++ b/modules/roles/server.nix
@@ -6,7 +6,9 @@
 #   - hardened SSH (key-only auth, no root login)
 #   - server networking (systemd-networkd instead of NetworkManager,
 #     which currently comes bundled via den.aspects.users)
-#   - the secrets aspect, once per-host sops keys exist
+#   - the secrets aspect: register the host in .sops.yaml first
+#     (ssh-keyscan -t ed25519 <host> | ssh-to-age, add anchor + rule,
+#     sops updatekeys secrets/*.yaml), then include den.aspects.secrets
 { den, ... }:
 {
   den.aspects.server.includes = [

--- a/modules/roles/workstation.nix
+++ b/modules/roles/workstation.nix
@@ -13,6 +13,7 @@
     den.aspects.nh
     den.aspects.users
     den.aspects.secrets-guard
+    den.aspects.secrets
     den.aspects.greetd
     den.aspects.fonts
     den.aspects.audio

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -28,16 +28,19 @@
     nixos = {
       imports = [ inputs.sops-nix.nixosModules.sops ];
 
-      sops.age = {
-        generateKey = true;
-        keyFile = "/var/lib/sops-nix/key.txt";
+      sops = {
+        defaultSopsFile = ../secrets/main.yaml;
+
+        # Canonical per-host identity: the SSH host key, converted to
+        # age at activation (ssh-to-age). Register new hosts in
+        # .sops.yaml and run `sops updatekeys` BEFORE enabling this
+        # aspect — otherwise activation fails loudly (by design).
+        age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+
+        # Don't import RSA host keys into a throwaway GPG keyring
+        # (sops-nix defaults this from services.openssh.hostKeys).
+        gnupg.sshKeyPaths = [ ];
       };
-
-      security.sudo.extraConfig = ''
-        Defaults env_keep += "SOPS_AGE_KEY_FILE"
-      '';
-
-      sops.defaultSopsFile = ../secrets/main.yaml;
     };
   };
 }

--- a/secrets/main.yaml
+++ b/secrets/main.yaml
@@ -1,16 +1,25 @@
-ssh_id_ed25519: ENC[AES256_GCM,data:uowCykTs9wqmhF4OhBaZiBxTHqRyVqQL2OqGRJyeQgQeuZMboXWZRbm26GUYk4FpRPQpOEUXjIfdANXpqOameL93qSl5N+Kh6N1ddPR1QuZZU3cLLj2KwLU81YBg4SudGAH/l23WrJMnmH+Sz1mQsNipbQ23e9sNJg8ydYXFfkAPm6BjnU1QcRKrEHSTa8v9NQqkmKalbYTusBVOHV2o+M9BhbOeCHs66PH8JKXsZZEw4ktFDkEw6CgNlhBfIY1kFI1oROzvznoFdQ/wKJHBF68P/PqJEctgai8k5sFbXmQLJ134Ruy5Oe6k6A0vmXTxrjY+1sPfCcMTbdYTX01tSSwb1Ivf43NP+92pf3Mq+h1uzmE2q8UgzugkEcpp9df0bFDjHE5Vm91gcdop0Nh1/mOVu7QmXqwkmLrZSuw21nP5V5wbKB05tRV0pMievZVu1t2Vuhb98mQ/AO0aGtnhTZrLzhKjHPUqLcN9/qT5Rw5Z8nglXST4RVZ/WgHJblZI9hQ2t9CZPRhIfQ9+GkhmtDVztHYlYEXN2PaWIaWSmZdC9bM=,iv:KfSF9ckUXsAOsSRhnkswsAOCt4j7RRx5JK8wfSW9HOg=,tag:PI6ZwCO0KbVLi45M19akbg==,type:str]
+ssh_id_ed25519: ENC[AES256_GCM,data:voLvMZBU4spRFdXDedtDKWaex0Lif18HnYSz/J0xzjsUCG3188cPfPcASPg8eElIvpSkvPq2MvU8hOFvgLY7aqdelrGhrrQEjZPbJwodfBmclUKnTSf8ZMCUl4UhpmsxVrHjSba+i30S2bfKjphzqD5vLjIV98mD7f+sMjKnbEgO4XQmFc6YeshsYwhUCfgDjbWfKov1G3oLBehy4RNEbDh4H/RA6geojVG3LeiFr8n91YWGp9noCQLYcgVjGmT9Krt9EhDyqIJKAy5ih1wMEdpEjyu8bVsz2G3SNckgsz6mm4gAofqyEj//JA2IbIeieJDrb47xIPW0U/s6u6ncrLHWOORNhftLMGGOnBOwqFiKLw1jBDGXMvCzanlOGTiSiSMFJtX1uwT5oZkkvUqTR26QNqkoQ0UdVJBcpBdo+/QwpQGsfYDHn/D7laCFk6OMtNr4E7ZajVgbvob1ebpmN9qYoQfWtvl4+1/z8L2+Ty0INaKctEZ9Y9AiUJ/gniMg+YmdvauVPK/bJRGaU1+zc+tM0w94F72IZXSK,iv:2+6pjqzs4T4/kbaM2lhYnhapuBHdUiRfnE5uTCSCpjg=,tag:k5EG4y6wLa6764LySfZHfg==,type:str]
 sops:
     age:
-        - recipient: age13avs5m2k7mpqp5ujw4ttdhx4zkcs2vmr0gp5g783atc2hgetdpcqc5gaql
+        - recipient: age100dcyxe580rdv2cuar3rwedjptzstutwr74psc5sxxxqr64y79xsgum4yk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1Qm5oNFRIUEgzbkdrUVE0
-            QWFOY0hKRUVXODVpOVRIOVZ1cXpTc1FWMmxFCjVXQ1ZjV3dJUG92a0V5anZLODdk
-            RnNJSnBYcnUzbnYwV1NhV1ZuN25NekkKLS0tIHp1elZtMjNxUlI4UmJpQTBJM0tV
-            dndBN3E3a0ljTjc0MXh6SCt1Q29uVHMKggDAkoEUGY4ICgf9d4mKpaXF8+Jr4eCM
-            Yhvto5tNiyoFUbQMGkEIXIn1d7w/HBs/G818PbsqcdZh9k0wLmkZUA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5ZUdHV1hibEtSc0lSZytL
+            M2ZlbHA0WEEzWk9LRGxDSzYxdGZFWWRqUGpFCmNrdkZFWXplT0pTV1BYVWhuUk11
+            dXhTYm9VaUo5UGsrdCt4RUgwY3FLUE0KLS0tIFF4MHI3ZStxTlJldXc2dnFJNThI
+            cEd2RW82bktmQXNVVUhEK1U4cGg3eFkKBqJWjhYLV3MoSpUVp0xsp0xkghO1Lk6X
+            9WPZa91xtrHhIUH9+n1X/aFBjykOynXvqsNuhyxG1wxYabVpO5rZKQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-02T14:19:38Z"
-    mac: ENC[AES256_GCM,data:NzgQyQ+0RkKk7NhrNM+uRIYEgOc+I8YKRI1FdgJ6mq5NvhNIwwW6uLz70lyl8UwXpbvd0nT4z7gvDNfkGzrJL9rugYPTIqOCkXpseRarqhZ6RReimDnqVP1cZQpHesN8i429WdN4q8WgXZHjdow+1X3A1T5xH7/SQjj7biLfLag=,iv:/uiwdm/yRsiVvjXnv1EGjFVhNAVa4dvIb1lVIHZlMR0=,tag:vJYq6qyrYJNCrl8VKy2z9g==,type:str]
+        - recipient: age1gqxz9qd4a245e4c5ruaka9e325un0zu74rrs5mugach32f7y3fyskakr4u
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuMGw3STFVVGkrTFN5RkRk
+            czB1c0tGUitrUi80eExVQTlVUS9DTjQvTEc4CjVReFdKR1ZzSGVkMGxQVGFpSU9T
+            NEo3aWpNclVBaTdLMHpoU0h0Y2M3WUEKLS0tIGpUdk8xbXNwMkZmTFBQc041SnZL
+            SE9KeENHTUs4bUxMN25WREhoNGR1ZUUK27pWDLCF5h+CEZsia9s7147rTuXotJQm
+            jCh0LNt2HHdADuEODm1AjiTsD92C4WMTgpd/4MYqOef3ltMH2iP+HA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-17T00:57:54Z"
+    mac: ENC[AES256_GCM,data:yAcjYtntRXarohQ/7/lEr5hAiBfq1fDHBgKMJeY8e3kG9mxWPof5qLVCHooe/YIvvHTq2Yw6BINpgTePkOd/J5CKRlVfm79eItR3aXw5KNmGxntZ0hASlr4lPDRK68BGy/2JrsXoOfQhHhe4RHWV5kJbaQjIGBxoFRAblpw1PGs=,iv:mdwmPIlz/oQDqsdEZDZ5wnbhc8DUx7alPPlcr7JZGt8=,tag:1BpDOcHruZ0ALg5Y6s7rNw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2


### PR DESCRIPTION
## Summary

- Adds a `.sops.yaml` recipient registry: `admin_ada` (personal editing key, `~/.config/sops/age/keys.txt`) plus one `host_<name>` recipient per machine.
- Host decryption identity is now derived from the SSH host key at activation via ssh-to-age (`sops.age.sshKeyPaths`) — no per-host key files, nothing to generate or back up per machine. `generateKey`/`keyFile` and the sudo `env_keep` workflow are gone; editing secrets needs no sudo.
- `secrets/main.yaml` was recreated from scratch: the old file's only recipient key was lost in a reinstall (undecryptable, harmless in history). The GitHub SSH key it held was rotated (new key registered for both auth and signing); sops-nix provisions it at `~/.ssh/github` with topology-derived owner.
- The `secrets` aspect is now part of the workstation role; sops/ssh-to-age/age added to the devShell.
- Docs: sops-nix chapter rewritten (registry, editing, recovery procedures), adding-a-host gains a mandatory registration step, CLAUDE.md updated.

## Registering the next machine

Must happen **before** the machine's first rebuild with the `secrets` aspect — otherwise activation fails loudly (by design):

```bash
ssh-keyscan -t ed25519 <host> | ssh-to-age    # get the age recipient
# add `- &host_<name> age1...` + creation rule to .sops.yaml, then:
sops updatekeys secrets/*.yaml
```

## Test plan

- [x] `just fmt` && `just check`
- [x] `just switch` on fern
- [x] Reboot: `~/.ssh/github → /run/secrets/ssh_id_ed25519` populated at boot
- [x] `ssh -T git@github.com` authenticates with the rotated key
- [x] Commit signing uses the rotated key (`SHA256:kxish…`)