### PR TITLE
feat: Bitwarden password manager (desktop app + rbw CLI)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(nix hash:*)",
       "Bash(nix develop:*)",
       "Bash(nix build:*)",
-      "Bash(systemctl status:*)"
+      "Bash(systemctl status:*)",
+      "Bash(ls:*)"
     ]
   }
 }

--- a/modules/cli/bundle.nix
+++ b/modules/cli/bundle.nix
@@ -27,6 +27,7 @@
       den.aspects.fzf
       den.aspects.fd
       den.aspects.ripgrep
+      den.aspects.rbw
       den.aspects.jq
     ];
   };

--- a/modules/cli/rbw.nix
+++ b/modules/cli/rbw.nix
@@ -1,0 +1,18 @@
+# modules/cli/rbw.nix — Bitwarden CLI client
+{ den, ... }:
+{
+  den.aspects.rbw.homeManager =
+    { pkgs, ... }:
+    {
+      programs.rbw = {
+        enable = true;
+        settings = {
+          email = "adanoelleyoung@gmail.com";
+          # Headless-safe; rbw is invoked from a terminal anyway.
+          pinentry = pkgs.pinentry-curses;
+          # base_url unset -> vault.bitwarden.com. When the homelab
+          # vaultwarden exists, set base_url here (one line).
+        };
+      };
+    };
+}

--- a/modules/desktop/bitwarden.nix
+++ b/modules/desktop/bitwarden.nix
@@ -1,0 +1,9 @@
+# modules/desktop/bitwarden.nix — Bitwarden desktop app
+{ den, ... }:
+{
+  den.aspects.bitwarden.homeManager =
+    { pkgs, ... }:
+    {
+      home.packages = [ pkgs.bitwarden-desktop ];
+    };
+}

--- a/modules/desktop/bundle.nix
+++ b/modules/desktop/bundle.nix
@@ -14,6 +14,7 @@
       den.aspects.screenshot
       den.aspects.gaming-hm
       den.aspects.daw
+      den.aspects.bitwarden
     ];
   };
 }


### PR DESCRIPTION
## Summary

- Adds the fleet's first password manager, as agreed during the multi-machine secrets migration (#21): the sops admin age key needs a convenient off-machine backup besides paper/USB.
- **`modules/cli/rbw.nix`** — rbw CLI aspect in the base `cli` bundle, so it reaches every host including future headless ones. Uses `pinentry-curses` (terminal-safe anywhere); `base_url` left unset (bitwarden.com free tier) with a one-line migration path to the planned homelab vaultwarden.
- **`modules/desktop/bitwarden.nix`** — Bitwarden desktop app aspect in the `desktop-apps` bundle, forwarded to ada on both graphical hosts (fern, moss) via the existing `provides.to-users` wiring. No host files touched.

Out of scope (future PRs): vaultwarden service for the homelab role, declarative browser extensions, managing gnome-keyring.

## Test plan

- [x] `just fmt` && `just check`
- [x] `just test` — closure diff shows rbw 1.13.2, bitwarden-desktop 2025.5.1, pinentry-curses added
- [x] statix/deadnix clean on all touched files
- [x] `just switch` on fern
- [x] `rbw login` → `rbw sync` → `rbw list`
- [x] Launch `bitwarden` desktop app
- [x] Create "sops admin age key" vault entry with contents of `~/.config/sops/age/keys.txt` — verified round-trip via `rbw get`; paper/USB copy retained