### PR TITLE
feat: autostart garden shell in Niri session

### DIFF
--- a/modules/desktop/niri.nix
+++ b/modules/desktop/niri.nix
@@ -67,6 +67,15 @@ in
           # ── Startup programs ─────────────────────────────────
           spawn-at-startup = [
             { command = [ "xwayland-satellite" ]; }
+            # Garden shell (quickshell) — receives the Mod+Slash/Tab/Comma
+            # IPC binds below; without it those binds silently do nothing.
+            {
+              command = [
+                "qs"
+                "-c"
+                "garden"
+              ];
+            }
             { command = [ "kitty" ]; }
             {
               command = [


### PR DESCRIPTION
## Summary

- Adds `qs -c garden` to Niri's `spawn-at-startup` so the garden shell is up on every login. The `Mod+Slash` (launcher), `Mod+Tab` (switcher), and `Mod+Comma` (settings) binds call into it over quickshell IPC — with no running instance they silently do nothing, and until now the shell had to be started manually each session (discovered while trying to launch the new Bitwarden app from #22).
- `qs` is already system-wide via the greetd aspect's `environment.systemPackages`; the `garden` config resolves through the existing `~/.config/quickshell/garden` symlink (unmanaged dev checkout, unchanged by this PR).

## Test plan

- [x] `just fmt` && `just check`
- [x] `just test` && `just switch` on fern
- [x] Log out/in (or restart niri) → garden shell auto-starts, `Mod+Slash` opens the launcher without manual `qs -c garden`