### PR TITLE
SSH hardening + documentation drift cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ Configuration is expressed as **den aspects** composed onto hosts and users.
 Current machines:
 
 - **fern** — x86_64 desktop workstation (AMD, Niri/Hyprland, pro audio, dev)
-- **moss** — Apple Silicon laptop (Asahi)
+- **moss** — Apple Silicon laptop (Asahi) — parked: hardware.nix is still
+  the installer placeholder and some aspects pull x86_64-only packages;
+  see the comment in modules/hosts.nix
 
 Planned: homelab server, dedicated gaming machine. The `modules/roles/`
 layer exists so those become "hardware file + role + quirks".

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -36,6 +36,7 @@
 
 # Desktop Environment
 
+- [Niri](desktop/niri.md)
 - [Hyprland](desktop/hyprland.md)
 - [Fern Shell (QuickShell)](desktop/fern-shell.md)
 - [Wallpaper & Theming](desktop/wallpaper-and-theming.md)
@@ -100,6 +101,7 @@
 
 - [SOPS-nix](security/sops-nix.md)
 - [Secret Guard](security/secret-guard.md)
+- [Password Manager](security/password-manager.md)
 
 ---
 

--- a/book/src/architecture/topology-and-hosts.md
+++ b/book/src/architecture/topology-and-hosts.md
@@ -5,16 +5,24 @@
 
 ## The topology
 
-The entire host/user structure is declared in three lines:
+The entire host/user structure is declared in a few lines:
 
 ```nix
 # modules/hosts.nix
 { ... }:
 {
   den.hosts.x86_64-linux.fern.users.ada = {};
-  den.hosts.aarch64-linux.moss.users.ada = {};
+  # moss is parked (see below)
+  # den.hosts.aarch64-linux.moss.users.ada = {};
 }
 ```
+
+> **Moss is currently parked.** Its `hardware.nix` is still the installer
+> placeholder and several aspects pull x86_64-only packages (gnat13, ldtk,
+> renderdoc), so the config cannot evaluate on aarch64-linux. Its topology
+> line is commented out in `modules/hosts.nix`; the host aspect and docs
+> below describe its intended shape. Re-enable after generating the real
+> hardware.nix and platform-gating those packages.
 
 The path structure is `den.hosts.<system>.<hostname>.users.<username>`. Den uses
 this to:
@@ -27,7 +35,7 @@ this to:
 
 ## The two hosts
 
-| Property | fern | moss |
+| Property | fern | moss (parked) |
 |----------|------|------|
 | Architecture | x86_64-linux | aarch64-linux |
 | GPU | AMD (Mesa/AMDGPU) | Apple Silicon (Asahi) |
@@ -35,7 +43,7 @@ this to:
 | Gaming | Steam, Gamescope, GameMode | Not included |
 | Cloud tools | AWS, LocalStack | Not included |
 | Dev toolchains | Rust, C/C++, TypeScript | Not included |
-| Desktop | Hyprland + Fern Shell | Hyprland + Fern Shell |
+| Desktop | Niri (+ Hyprland fallback) + garden shell | Niri (+ Hyprland fallback) + garden shell |
 | Shells | Nushell, Starship, Zoxide | Nushell, Starship, Zoxide |
 | Git suite | Full suite | Full suite |
 

--- a/book/src/desktop/hyprland.md
+++ b/book/src/desktop/hyprland.md
@@ -3,6 +3,9 @@
 > Hyprland is the Wayland compositor at the center of the desktop environment,
 > configured with dwindle tiling, Catppuccin colors, and hjkl-based navigation.
 
+Hyprland is now the **fallback session**: [Niri](niri.md) is the primary
+compositor, and greetd offers both sessions at login.
+
 The Hyprland configuration is a den aspect (`den.aspects.hyprland`) defined in
 `modules/desktop/hyprland.nix`, with sub-modules split into
 `modules/desktop/_hyprland/`. The underscore prefix convention (`_hyprland/`)

--- a/book/src/desktop/niri.md
+++ b/book/src/desktop/niri.md
@@ -1,0 +1,95 @@
+# Niri
+
+> Niri is the primary compositor: a scrollable-tiling Wayland compositor where
+> windows live in columns on an infinite horizontal strip, paired with the
+> garden shell (QuickShell) for the bar and overlays. Hyprland remains
+> available as a [fallback session](hyprland.md).
+
+The Niri configuration is a den aspect (`den.aspects.niri`) defined in
+`modules/desktop/niri.nix`, with both a `nixos` side and a `homeManager` side.
+
+## System side (nixos)
+
+The `nixos` side enables the compositor and its supporting hardware/portal
+plumbing:
+
+- `programs.niri.enable = true` (option provided by
+  [niri-flake](https://github.com/sodiboo/niri-flake))
+- `hardware.i2c.enable = true` — DDC/CI brightness control of external
+  monitors via `ddcutil`; the `users` aspect adds users to the `i2c` group
+  when this is on
+- System packages: `xwayland-satellite` (XWayland support) and `ddcutil`
+- XDG portals: `xdg-desktop-portal-gnome` + `xdg-desktop-portal-gtk`
+
+## Home Manager side
+
+The `homeManager` side writes the full Niri config via
+`programs.niri.settings`, themed with the garden-shell palette
+(`inputs.garden-shell.lib.palette`).
+
+### Named workspaces (channels)
+
+Five named workspaces act as channels: **studio**, **research**, **writing**,
+**music**, **system**. `Super+1-5` focuses them, `Super+Shift+1-5` moves the
+focused window.
+
+### Startup
+
+`spawn-at-startup` launches:
+
+- `xwayland-satellite` — X11 app support
+- `qs -c garden` — the garden shell (QuickShell); the IPC binds below
+  silently do nothing without it
+- `kitty` (opens on *research*) and `kitty -e btop` (opens on *system*), via
+  `at-startup` window rules
+
+### Garden shell IPC binds
+
+The garden shell overlays are driven over QuickShell IPC:
+
+| Binding | Action |
+|---------|--------|
+| `Super+Slash` | `qs -c garden ipc call garden toggleLauncher` |
+| `Super+Tab` | `qs -c garden ipc call garden toggleSwitcher` |
+| `Super+Comma` | `qs -c garden ipc call garden toggleSettings` |
+
+### Other notable binds
+
+| Binding | Action |
+|---------|--------|
+| `Super+H/L`, `Super+J/K` | Focus column left/right, window down/up |
+| `Super+Shift+H/L/J/K` | Move column/window |
+| `Super+N` / `Super+B` | Spawn kitty / firefox |
+| `Super+F` / `Super+A` | Maximize column / toggle overview |
+| `Super+R`, `Super+Minus/Equal` | Preset / relative column widths |
+| `Print` / `Super+Print` | Screenshot (to `~/media/screenshots/`) / window screenshot |
+| `XF86MonBrightness*` | External monitor brightness via `ddcutil setvcp 10` |
+| `XF86Audio*` | Volume via `wpctl` |
+
+Window rules also float scratchpads (`garden`, `scratchpad-terminal`,
+`lazygit`) and color-code borders for SSH host tiers (HPC/GPU/homelab) by
+window title.
+
+## The host-level import gotcha
+
+The niri-flake NixOS module is imported **once at the host level**
+(`modules/host-fern.nix`), not inside the aspect — importing it from an
+aspect that gets included twice causes duplicate option declarations. For the
+same reason:
+
+- `den.aspects.niri` is deliberately **not** in the `desktop-apps` bundle or
+  the workstation role. Its `homeManager` side sets `programs.niri.*` options
+  that only exist for users on hosts that import the niri-flake module.
+- Hosts opt in by including `den.aspects.niri` alongside the module import,
+  and it reaches users via the host's `provides.to-users` machinery.
+- A new host that wants Niri needs both the import and the include (see the
+  troubleshooting note in CLAUDE.md).
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `modules/desktop/niri.nix` | The niri aspect (nixos + homeManager sides) |
+| `modules/host-fern.nix` | niri-flake module import + aspect include |
+| `modules/desktop/greetd.nix` | Login sessions (Niri primary, Hyprland fallback) |
+| `modules/users.nix` | `i2c` group membership when `hardware.i2c` is enabled |

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -7,8 +7,8 @@ discovery.
 
 ## Key technologies
 
-- **Hyprland** -- Wayland compositor with per-workspace wallpapers and a custom
-  QuickShell bar
+- **Niri** -- Primary scrollable-tiling Wayland compositor, paired with the
+  garden shell (QuickShell); Hyprland is retained as a fallback session
 - **Helix** -- Modal text editor with per-language LSP integration
 - **Nushell** -- Structured-data shell with Starship prompt and Zoxide
   navigation
@@ -24,7 +24,7 @@ discovery.
 ## Quick start
 
 ```bash
-# Enter the dev shell (provides just, mdbook, nixpkgs-fmt)
+# Enter the dev shell (provides just, mdbook, nixfmt)
 nix develop            # or: direnv allow
 
 # Test a rebuild without switching

--- a/book/src/reference/aspect-index.md
+++ b/book/src/reference/aspect-index.md
@@ -19,8 +19,8 @@ minimal).
 | Aspect | File | Type | Applied |
 |--------|------|------|---------|
 | `ada` | `modules/user-ada.nix` | homeManager | ada, every host (base: shells, cli, git, ssh) |
-| `ada-desktop` | `modules/user-ada-desktop.nix` | homeManager | forwarded by fern, moss (Hyprland prefs + desktop-apps) |
-| `ada-dev` | `modules/user-ada-dev.nix` | homeManager | forwarded by fern, moss (devtools bundle) |
+| `ada-desktop` | `modules/user-ada-desktop.nix` | homeManager | forwarded by fern, moss (parked) (desktop prefs + desktop-apps) |
+| `ada-dev` | `modules/user-ada-dev.nix` | homeManager | forwarded by fern, moss (parked) (devtools bundle) |
 
 ## Role aspects
 
@@ -28,7 +28,7 @@ Host role bundles — compose these instead of long per-host include lists.
 
 | Aspect | File | Includes |
 |--------|------|----------|
-| `workstation` | `modules/roles/workstation.nix` | core, nh, users, secrets-guard, greetd, fonts, audio, docker |
+| `workstation` | `modules/roles/workstation.nix` | core, nh, users, secrets-guard, secrets, greetd, fonts, audio, docker |
 | `dev-machine` | `modules/roles/dev-machine.nix` | c-cpp, localstack, rust, node-ts, aws-cli |
 | `server` | `modules/roles/server.nix` | core, nh, users, secrets-guard (skeleton — hardening TODOs in file) |
 
@@ -36,9 +36,9 @@ Host role bundles — compose these instead of long per-host include lists.
 
 | Aspect | File | Includes |
 |--------|------|----------|
-| `cli` | `modules/cli/bundle.nix` | bat, broot, claude-code, crypt, delta, ghostty, glow, helix, hyfetch, nix-tree, prettier, tree, audio-tools |
+| `cli` | `modules/cli/bundle.nix` | bat, broot, claude-code, crypt, delta, ghostty, glow, helix, hyfetch, nix-diff, nix-tree, prettier, tree, audio-tools, kitty, kakoune, yazi, lazygit, btop, fzf, fd, ripgrep, rbw, jq |
 | `git-suite` | `modules/git/bundle.nix` | git-core, git-aliases, git-identities, git-github, git-tools, git-safety, git-help, git-claude-code, git-claude-enhanced, git-worktree, git-worktree-enhanced, git-helix, git-prompts |
-| `desktop-apps` | `modules/desktop/bundle.nix` | niri, hyprland, chromium, obs, screenshot, gaming-hm, daw |
+| `desktop-apps` | `modules/desktop/bundle.nix` | hyprland, chromium, obs, screenshot, gaming-hm, daw, bitwarden (niri is deliberately NOT here — hosts forward it via provides.to-users) |
 | `devtools` | `modules/devtools/bundle.nix` | docker, rust, node-ts, c-cpp, python, csharp, ada-lang, localstack, zig, gamedev |
 | `shells` | `modules/shells/bundle.nix` | nushell, starship, zoxide, devenv |
 
@@ -63,10 +63,10 @@ Aspects providing NixOS system-level configuration.
 | `localstack` | `modules/devtools/localstack.nix` | LocalStack container, awslocal wrapper | fern |
 | `monitoring` | `modules/monitoring.nix` | Hardware sensors (lm_sensors) | fern |
 | `nh` | `modules/cli/nh.nix` | nh rebuild helper + scheduled clean | fern |
-| `niri` | `modules/desktop/niri.nix` | Niri compositor (nixos enable + HM settings) | fern |
+| `niri` | `modules/desktop/niri.nix` | Niri compositor (nixos enable + HM settings) | fern (also forwarded to users via host provides.to-users) |
 | `node-ts` | `modules/devtools/node-ts.nix` | Node.js, pnpm, Deno, CDK, nix-ld | fern |
 | `rust` | `modules/devtools/rust.nix` | Stable Rust, rust-analyzer, cargo tools, hardening | fern |
-| `secrets` | `modules/secrets.nix` | SOPS-nix, age key, SSH key decryption | moss |
+| `secrets` | `modules/secrets.nix` | SOPS-nix, age key, SSH key decryption | fern (via workstation role), moss (parked) |
 | `secrets-guard` | `modules/secrets-guard.nix` | git-secrets, trufflehog | fern, moss |
 | `teams` | `modules/desktop/teams.nix` | Microsoft Teams | fern |
 | `users` | `modules/users.nix` | User account, NetworkManager, SSH | fern, moss |
@@ -82,16 +82,27 @@ Aspects providing Home Manager user-level configuration.
 | `audio-tools` | `modules/cli/audio-tools.nix` | LSP audio plugins |
 | `bat` | `modules/cli/bat.nix` | Bat syntax highlighter, man pager |
 | `broot` | `modules/cli/broot.nix` | File explorer with Nushell integration |
+| `btop` | `modules/cli/btop.nix` | System monitor |
 | `claude-code` | `modules/cli/claude-code.nix` | Claude Code CLI package |
 | `crypt` | `modules/cli/crypt.nix` | Age encryption tool |
 | `delta` | `modules/cli/delta.nix` | Delta diff tool, Catppuccin Frappe theme |
+| `fd` | `modules/cli/fd.nix` | Fast file finder |
+| `fzf` | `modules/cli/fzf.nix` | Fuzzy finder |
 | `ghostty` | `modules/cli/ghostty.nix` | Ghostty terminal emulator |
 | `glow` | `modules/cli/glow.nix` | Markdown viewer |
 | `helix` | `modules/cli/helix.nix` | Helix editor, LSP, theme |
 | `hyfetch` | `modules/cli/hyfetch.nix` | System info display (fastfetch) |
+| `jq` | `modules/cli/jq.nix` | JSON processor |
+| `kakoune` | `modules/cli/kakoune.nix` | Kakoune editor |
+| `kitty` | `modules/cli/kitty.nix` | Kitty terminal (garden terminal stack) |
+| `lazygit` | `modules/cli/lazygit.nix` | Git TUI |
+| `nix-diff` | `modules/cli/nix-diff.nix` | Derivation diff tool |
 | `nix-tree` | `modules/cli/nix-tree.nix` | Nix dependency visualizer |
 | `prettier` | `modules/cli/prettier.nix` | Code formatter |
+| `rbw` | `modules/cli/rbw.nix` | Bitwarden CLI client (see [Password Manager](../security/password-manager.md)) |
+| `ripgrep` | `modules/cli/ripgrep.nix` | Fast grep |
 | `tree` | `modules/cli/tree.nix` | Directory tree viewer |
+| `yazi` | `modules/cli/yazi.nix` | Terminal file manager |
 
 ### Git suite
 
@@ -115,7 +126,8 @@ Aspects providing Home Manager user-level configuration.
 
 | Aspect | File | Description |
 |--------|------|-------------|
-| `hyprland` | `modules/desktop/hyprland.nix` | Hyprland compositor + sub-modules |
+| `hyprland` | `modules/desktop/hyprland.nix` | Hyprland compositor (fallback session) + sub-modules |
+| `bitwarden` | `modules/desktop/bitwarden.nix` | Bitwarden desktop app |
 | `chromium` | `modules/desktop/chromium.nix` | Ungoogled Chromium |
 | `gaming-hm` | `modules/desktop/gaming-hm.nix` | MangoHud, Lutris, ProtonUp |
 | `nyxt` | `modules/desktop/nyxt.nix` | Nyxt browser |

--- a/book/src/security/password-manager.md
+++ b/book/src/security/password-manager.md
@@ -1,0 +1,53 @@
+# Password Manager
+
+> Bitwarden is the password manager: the desktop app for graphical use and
+> `rbw` for the terminal. The vault also plays a role in the sops age-key
+> recovery story.
+
+## Desktop app
+
+`den.aspects.bitwarden` (`modules/desktop/bitwarden.nix`) installs
+`bitwarden-desktop` as a Home Manager package. It is part of the
+`desktop-apps` bundle, so it arrives with the `ada-desktop` layer on
+graphical hosts only — headless hosts never pull a GUI vault.
+
+## rbw (CLI)
+
+`den.aspects.rbw` (`modules/cli/rbw.nix`) configures
+[rbw](https://github.com/doy/rbw), an unofficial Bitwarden CLI client with a
+background agent (no re-typing the master password for every lookup). It is
+part of the `cli` bundle, so it is available on every host via the base user
+layer.
+
+Configuration notes:
+
+- `pinentry` is `pinentry-curses` — headless-safe, since rbw is invoked from
+  a terminal anyway
+- `base_url` is intentionally unset, which means the official
+  `vault.bitwarden.com`. When the homelab vaultwarden exists, pointing the
+  whole setup at it is a one-line change in `modules/cli/rbw.nix`
+
+Typical usage:
+
+```bash
+rbw login        # once per machine
+rbw unlock       # start an agent session
+rbw get <entry>  # print a password
+rbw generate 32  # generate and store a new password
+```
+
+## Role in age-key recovery
+
+The sops [recovery procedures](sops-nix.md#recovery-procedures) depend on the
+admin age key (`~/.config/sops/age/keys.txt`) never being lost together with
+all registered hosts. The vault holds a copy of the admin age key as a secure
+note, giving an off-machine backup that survives full hardware loss: restore
+the key from Bitwarden, and every sops-encrypted secret is editable again.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `modules/desktop/bitwarden.nix` | Bitwarden desktop app (desktop-apps bundle) |
+| `modules/cli/rbw.nix` | rbw CLI client + agent (cli bundle) |
+| `book/src/security/sops-nix.md` | The recovery story the vault backs up |

--- a/modules/roles/server.nix
+++ b/modules/roles/server.nix
@@ -3,7 +3,6 @@
 # Landing zone for the homelab host: no greeter, no fonts, no audio,
 # no desktop user layers. Before the first server host ships, this
 # role still needs (tracked in the multi-machine review):
-#   - hardened SSH (key-only auth, no root login)
 #   - server networking (systemd-networkd instead of NetworkManager,
 #     which currently comes bundled via den.aspects.users)
 #   - the secrets aspect: register the host in .sops.yaml first

--- a/modules/users.nix
+++ b/modules/users.nix
@@ -29,6 +29,13 @@
               users.users = lib.genAttrs (map (u: u.userName) (lib.attrValues host.users)) (_: {
                 isNormalUser = true;
                 shell = pkgs.fish;
+                # Key-only sshd (below) needs at least one authorized key,
+                # or hosts built from this config are unreachable over SSH.
+                # This is ada's sops-managed key (~/.ssh/github); public
+                # halves are safe to commit.
+                openssh.authorizedKeys.keys = [
+                  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILFcuaT78TweAsGP6nqUmqIV2sx7mF1Jt0mqtMKV+4Ft ada@fern github"
+                ];
                 extraGroups =
                   [
                     "wheel"

--- a/modules/users.nix
+++ b/modules/users.nix
@@ -55,7 +55,16 @@
       programs.fish.enable = true;
 
       networking.networkmanager.enable = true;
-      services.openssh.enable = true;
+      # Key-only SSH fleet-wide: the workflow is entirely key-based, so
+      # never accept passwords on port 22. PermitRootLogin already
+      # defaults to "prohibit-password".
+      services.openssh = {
+        enable = true;
+        settings = {
+          PasswordAuthentication = false;
+          KbdInteractiveAuthentication = false;
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- **feat(security)**: disable SSH password + keyboard-interactive auth fleet-wide in the `users` aspect (`modules/users.nix`) — the workflow is entirely key-based, and the future homelab server inherits key-only auth for free. Drops the now-done "hardened SSH" TODO from the server role header.
- **docs(book)**: catch the mdBook up to reality — new Niri chapter (primary compositor, garden shell IPC binds, host-level niri-flake import gotcha), new Password Manager page (Bitwarden desktop + rbw + age-key recovery role), aspect-index rows synced to actual bundles/roles, moss consistently marked as parked across CLAUDE.md / topology chapter / index, intro fixed (Niri bullet, nixfmt).

## Test plan
- [x] `nix flake check` passes
- [x] `nix eval .#nixosConfigurations.fern...toplevel.drvPath` evaluates
- [x] `mdbook build book` — both new chapters render, SUMMARY links resolve
- [ ] `just test`, then after `just switch`: `sudo sshd -T | grep -iE 'passwordauthentication|kbdinteractiveauthentication'` → both `no`
- [ ] key login still works: `ssh localhost true`