### PR TITLE
Un-hardcode nh flake path + garden-shell lock update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -271,11 +271,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1775752826,
-        "narHash": "sha256-j/bXwIyxiNWVp2AZVg1I3xeUiiV7xTvZbgfC/y5OJA0=",
+        "lastModified": 1784262351,
+        "narHash": "sha256-OBPY4nWLZhDQGZdPlEkDRo7O0kyGDejMVbB+/GDGz1c=",
         "owner": "adanoelle",
         "repo": "garden-shell",
-        "rev": "cebff06ba03d086e6be6126ac6a74ee941591de7",
+        "rev": "37222b03a75c92913ffdc46bc7ee75e8c5157aef",
         "type": "github"
       },
       "original": {

--- a/modules/cli/nh.nix
+++ b/modules/cli/nh.nix
@@ -2,7 +2,7 @@
 { den, ... }:
 {
   den.aspects.nh.nixos =
-    { lib, ... }:
+    { config, lib, ... }:
     {
       programs.nh = {
         enable = true;
@@ -10,8 +10,10 @@
         # upstream declares programs.nh.flake as `nullOr str` with an
         # OPTION default of null and never defines it, so nothing competes
         # at normal priority. Hosts where the checkout lives elsewhere
-        # just set programs.nh.flake plainly.
-        flake = lib.mkDefault "/home/ada/src/fern";
+        # just set programs.nh.flake plainly (mkDefault values are lazily
+        # discarded, so this default never evaluates on those hosts).
+        # Home dir is derived from the user account rather than hardcoded.
+        flake = lib.mkDefault "${config.users.users.ada.home}/src/fern";
         clean = {
           enable = true;
           dates = "weekly";


### PR DESCRIPTION
## Summary
- `modules/cli/nh.nix`: derive the flake path from `config.users.users.ada.home` instead of hardcoding `/home/ada` (NixOS aspect, so `home.homeDirectory` is unavailable; stays lazy under `mkDefault`)
- update `garden-shell` input to the merged code-review hardening (adanoelle/garden-shell#3)

## Test plan
- [x] `nix flake check` after the nh.nix change and after the lock update
- [x] Full system eval verified earlier with `--override-input` (seed activation script renders, `garden-themes` reaches ada's `home.packages`)
- [ ] `just switch` on fern to deploy the locked revision