### PR TITLE
feat: bluetooth aspect

### DIFF
--- a/modules/bluetooth.nix
+++ b/modules/bluetooth.nix
@@ -1,0 +1,38 @@
+# modules/bluetooth.nix — BlueZ + PipeWire bluetooth audio
+#
+# Enables the bluetooth stack with experimental features (battery
+# reporting for AirPods) and configures WirePlumber to prefer AAC
+# codec over SBC for bluetooth audio quality.
+{ ... }:
+{
+  den.aspects.bluetooth.nixos =
+    { pkgs, ... }:
+    {
+      hardware.bluetooth = {
+        enable = true;
+        powerOnBoot = true;
+        settings = {
+          General = {
+            Experimental = true;
+            FastConnectable = true;
+          };
+        };
+      };
+
+      services.pipewire.wireplumber.extraConfig."20-bluetooth-codecs" = {
+        "monitor.bluez.rules" = [
+          {
+            matches = [
+              { "device.name" = "~bluez_card.*"; }
+            ];
+            actions.update-props = {
+              "bluez5.auto-connect" = "[ a2dp_sink hfp_hf ]";
+              "bluez5.codecs" = "[ aac sbc_xq sbc ]";
+            };
+          }
+        ];
+      };
+
+      environment.systemPackages = [ pkgs.bluez ];
+    };
+}

--- a/modules/roles/workstation.nix
+++ b/modules/roles/workstation.nix
@@ -17,6 +17,7 @@
     den.aspects.greetd
     den.aspects.fonts
     den.aspects.audio
+    den.aspects.bluetooth
     den.aspects.docker
   ];
 }


### PR DESCRIPTION
## Summary

- Add `modules/bluetooth.nix` den aspect — BlueZ with experimental features (AirPods battery reporting), FastConnectable, WirePlumber AAC codec preference
- Add `den.aspects.bluetooth` to workstation role

## Test plan

- [ ] `nix flake check` passes
- [ ] `just switch` deploys successfully
- [ ] `bluetoothctl show` reports Powered: yes
- [ ] AirPods connect with AAC codec (check `wpctl status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)