### PR TITLE
feat(desktop): add Teams to work user with full-width Niri rules

### DIFF
--- a/modules/desktop/niri.nix
+++ b/modules/desktop/niri.nix
@@ -211,6 +211,7 @@ in
 
               # Fullscreen & overview
               "${mod}+F".action.maximize-column = [ ];
+              "${mod}+Shift+F".action.fullscreen-window = [ ];
               "${mod}+A".action.toggle-overview = [ ];
 
               # Column width cycling
@@ -359,6 +360,16 @@ in
             {
               matches = [ { app-id = "^lazygit$"; } ];
               open-floating = true;
+            }
+
+            # Full-width apps
+            {
+              matches = [{ app-id = "^libreoffice"; }];
+              default-column-width.proportion = 1.0;
+            }
+            {
+              matches = [{ app-id = "^teams-for-linux$"; }];
+              default-column-width.proportion = 1.0;
             }
 
             # Host tier borders — HPC (urgent red)

--- a/modules/desktop/teams.nix
+++ b/modules/desktop/teams.nix
@@ -1,7 +1,15 @@
 _: {
-  den.aspects.teams.nixos =
-    { pkgs, ... }:
-    {
-      environment.systemPackages = with pkgs; [ teams-for-linux ];
-    };
+  den.aspects.teams = {
+    nixos =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = with pkgs; [ teams-for-linux ];
+      };
+
+    homeManager =
+      { pkgs, ... }:
+      {
+        home.packages = [ pkgs.teams-for-linux ];
+      };
+  };
 }

--- a/modules/user-ada-work.nix
+++ b/modules/user-ada-work.nix
@@ -23,6 +23,7 @@
       den.aspects.imv
       den.aspects.pdf
       den.aspects.screenshot
+      den.aspects.teams
     ];
 
     homeManager =


### PR DESCRIPTION
## Summary
- Add homeManager side to teams aspect for standalone home-manager hosts (work laptop)
- Include teams aspect in the ada-work user layer
- Add `Mod+Shift+F` keybind for fullscreen-window in Niri
- Add full-width window rules for LibreOffice and Teams

## Test plan
- [ ] `just check` passes
- [ ] `just test` on fern
- [ ] Verify Teams opens at full column width in Niri
- [ ] Verify `Mod+Shift+F` triggers fullscreen-window

🤖 Generated with [Claude Code](https://claude.com/claude-code)